### PR TITLE
chore: remove "visit URL" prompt from manage_oauth.py

### DIFF
--- a/installation_scripts/manage_oauth.py
+++ b/installation_scripts/manage_oauth.py
@@ -345,9 +345,6 @@ def setup(
         typer.echo("\nOAuth Authorization URI:")
         typer.echo(f"\n{auth_uri}\n")
         typer.echo(
-            "Please visit the above URL to complete the OAuth authorization flow."
-        )
-        typer.echo(
             "\nAfter authorization, run 'make oauth-create-auth' to register the authorization."
         )
 


### PR DESCRIPTION
Removed the CLI output message prompting the user to visit the OAuth authorization flow URL in `installation_scripts/manage_oauth.py`.

---
*PR created automatically by Jules for task [11274338225461858927](https://jules.google.com/task/11274338225461858927) started by @dandye*